### PR TITLE
add Python2 shebang to helper.py

### DIFF
--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 """
     scripts.init_webhook


### PR DESCRIPTION
allows usage of './helper.py' instead of 'python helper.py'