### PR TITLE
Use PyOpenSSL instead of default SSL module

### DIFF
--- a/matterllo/__init__.py
+++ b/matterllo/__init__.py
@@ -21,6 +21,9 @@ from slugify import slugify
 from matterllo.parser import Parser
 from matterllo.utils import config
 
+import urllib3.contrib.pyopenssl
+urllib3.contrib.pyopenssl.inject_into_urllib3()
+
 logging.basicConfig(
     level=logging.INFO, format='[%(asctime)s] [%(levelname)s] %(message)s')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ PyYAML==3.11
 matterhook==0.1
 py-trello==0.4.3
 python-slugify==1.2.0
+pyopenssl==0.13
+ndg-httpsclient==0.4.1
+pyasn1==0.1.9

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ install_requires = [
     'matterhook==0.1',
     'py-trello==0.4.3',
     'python-slugify==1.2.0',
+    'pyopenssl==0.13',
+    'ndg-httpsclient==0.4.1',
+    'pyasn1==0.1.9'
 ]
 
 tests_require = []


### PR DESCRIPTION
+ enables SNI support
+ disables SSL compression

See:
http://urllib3.readthedocs.io/en/latest/security.html#openssl-pyopenssl

This is necessary if you happen to have both GitLab and Mattermost running on the same server but using different certificates.

No SNI: `mattermost.example.com` and `gitlab.example.com` work if cert has `*.example.com`
SNI: `mattermost.example.com` and `gitlab.example.com` can use individual certificates on one host.

**Note**: Please consider whether the instructions for installing requirements need to be updated too. This is the line from the link:

    pip install pyopenssl ndg-httpsclient pyasn1