### PR TITLE
Avoid apt cache in Docker image to save image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1.0.0-experimental
 FROM python:3.7-buster
 
-RUN apt-get update
-RUN apt-get upgrade -y
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 RUN --mount=type=ssh pip3 install -r requirements.txt


### PR DESCRIPTION
This change will reduce the image size about 17MB 🎉 

```sh
$ docker images
REPOSITORY                    TAG                 IMAGE ID            CREATED             SIZE
after                         latest              fd1b7ae22b9e        3 minutes ago       961MB
before                        latest              9555b87dacbf        9 minutes ago       978MB
```