### PR TITLE
Update "requests" from v2.21.0 to v2.25.1, fix #71

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ py-trello==0.7.0
 pylint==1.8.1
 python-dateutil==2.6.0
 pytz==2018.9
-requests==2.21.0
+requests==2.25.1
 requests-oauthlib==0.7.0
 six==1.11.0
 urllib3==1.26.5


### PR DESCRIPTION
Pull request #71 updates "urllib3" from 1.24.2 to 1.26.5, however,
"requests" v2.21.0 depends on urllib3 < 1.25 and >= 1.21.1, so
there was a dependency conflict need to be resolved.

cc @Lujeni