### PR TITLE
Fix unicode table name is not correctly handled

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -20,7 +20,7 @@ class Board(models.Model):
         verbose_name_plural = "boards"
 
     def __str__(self):
-        return self.name
+        return "{}".format(self.name)
 
     def __unicode__(self):
         return "{}".format(self.name)

--- a/core/views/board.py
+++ b/core/views/board.py
@@ -40,9 +40,9 @@ class BoardView(ListView):
 
             for board in boards:
                 print("BOARD_ID:", board.id)
-                slug_board = slugify(board.name, allow_unicode=False)
+                print("BOARD_NAME:", board.name)
                 b, created = Board.objects.get_or_create(
-                    name=slug_board,
+                    name=board.name,
                     trello_board_id=board.id,
                     trello_token=token,
                 )
@@ -53,7 +53,7 @@ class BoardView(ListView):
                 result = trello_client.create_hook(url, board.id)
                 print(
                     "create trello hook :: callback={} :: board={} :: result={}".format(
-                        url, slug_board, result
+                        url, board.id, result
                     )
                 )
             return super(BoardView, self).get(request)


### PR DESCRIPTION
Hi, I found table name handling in the board view seems unicode enabled.
It seems that [slugify ](https://github.com/Lujeni/matterllo/compare/master...benok:matterllo:fix-unicode-table-name?expand=1#diff-aaed7d723743a9bf6d8bd0e0e39ab56b9759f781bff10ac314a70ed06d762941L43) isn't required.

With this patch, all my boards are correctly listed up.
(Not tested well, but it works for me.)

